### PR TITLE
Migrate to textScaler from the deprecated textScaleFactor

### DIFF
--- a/lib/src/presentation/app.dart
+++ b/lib/src/presentation/app.dart
@@ -58,7 +58,10 @@ class App extends StatelessWidget {
             builder: (BuildContext context, Widget? widget) => MediaQuery(
               data: MediaQuery.of(context)
                   // Override device text scale factor
-                  .copyWith(textScaleFactor: 1, devicePixelRatio: 1),
+                  .copyWith(
+                devicePixelRatio: 1,
+                textScaler: const TextScaler.linear(1),
+              ),
               child: widget!,
             ),
           );


### PR DESCRIPTION
### Description

This Pull Request addresses the deprecation of `textScaleFactor` by migrating to `textScaler` for text scaling in the application. The changes ensure compatibility with the latest Flutter recommendations and best practices, providing a more robust and future-proof solution for handling text scaling.

### Changes Made

1. **Migration to textScaler**:
   - Replaced the deprecated `textScaleFactor` with `textScaler` throughout the codebase to align with the latest Flutter guidelines.

### Why

- **Compatibility with Latest Flutter Recommendations**: Migrating to `textScaler` ensures compatibility with the latest Flutter recommendations, helping to future-proof the codebase.

- **Improved Maintainability**: Adopting the recommended approach for text scaling enhances code maintainability by aligning with the evolving standards of the Flutter framework.
